### PR TITLE
Outbound optimisations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,39 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>in.succinct.beckn</groupId>
-  <artifactId>gateway.plugin</artifactId>
-  <version>1.0-SNAPSHOT</version>
-  <name>gateway.plugin</name>
-  <description>Succinct plugin to beckn gateway</description>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>in.succinct.beckn</groupId>
+    <artifactId>gateway.plugin</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>gateway.plugin</name>
+    <description>Succinct plugin to beckn gateway</description>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <revision>2.13-SNAPSHOT</revision>
     </properties>
     <build>
         <plugins>
-	      <plugin>
-		  <groupId>org.apache.maven.plugins</groupId>
-		  <artifactId>maven-compiler-plugin</artifactId>
-		  <version>3.5.1</version>
-		  <configuration>
-		    <source>11</source>
-		    <target>11</target>
-		  </configuration>
-	      </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>
-    <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>LATEST</version>
-        <scope>test</scope>
-    </dependency>
         <dependency>
-            <groupId>in.succinct</groupId>
-            <artifactId>id.core</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>LATEST</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>in.succinct</groupId>

--- a/src/main/java/in/succinct/beckn/gateway/controller/BgController.java
+++ b/src/main/java/in/succinct/beckn/gateway/controller/BgController.java
@@ -27,6 +27,7 @@ import com.venky.swf.sql.Operator;
 import com.venky.swf.sql.Select;
 import com.venky.swf.views.BytesView;
 import com.venky.swf.views.View;
+
 import in.succinct.beckn.Acknowledgement;
 import in.succinct.beckn.Acknowledgement.Status;
 import in.succinct.beckn.City;
@@ -46,12 +47,14 @@ import in.succinct.catalog.indexer.ingest.CatalogDigester;
 import in.succinct.catalog.indexer.ingest.CatalogSearchEngine;
 import in.succinct.onet.core.adaptor.NetworkAdaptor;
 import in.succinct.onet.core.adaptor.NetworkAdaptorFactory;
+
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 
 import javax.crypto.KeyAgreement;
 import javax.crypto.SecretKey;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -65,6 +68,8 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -75,28 +80,30 @@ import java.util.logging.Level;
  */
 @SuppressWarnings("unused")
 public class BgController extends Controller {
+
     public BgController(Path path) {
         super(path);
     }
 
     /**
      * Give a NACK response
+     *
      * @param request - incoming request
      * @param realm - caller
      * @return a nack response
      */
-    public View nack(Request request, String realm){
+    public View nack(Request request, String realm) {
         Acknowledgement nack = new Acknowledgement(Status.NACK);
         Response response = new Response(new Acknowledgement(Status.NACK));
         String sResponse = response.toString();
 
-        Config.instance().getLogger(BgController.class.getName()).log(Level.WARNING,sResponse);
-        BGEventEmitter.getInstance().log_request_processed(request.getContext(),0);
+        Config.instance().getLogger(BgController.class.getName()).log(Level.WARNING, sResponse);
+        BGEventEmitter.getInstance().log_request_processed(request.getContext(), 0);
 
         return new BytesView(getPath(),
                 sResponse.getBytes(StandardCharsets.UTF_8),
-                MimeType.APPLICATION_JSON,"WWW-Authenticate","Signature realm=\""+realm+"\"",
-                "headers=\"(created) (expires) digest\""){
+                MimeType.APPLICATION_JSON, "WWW-Authenticate", "Signature realm=\"" + realm + "\"",
+                "headers=\"(created) (expires) digest\"") {
             @Override
             public void write() throws IOException {
                 super.write(HttpServletResponse.SC_UNAUTHORIZED);
@@ -105,41 +112,41 @@ public class BgController extends Controller {
     }
 
     @RequireLogin(value = false)
-    public View log(long id) throws IOException{
-        if (!Config.instance().isDevelopmentEnvironment()){
+    public View log(long id) throws IOException {
+        if (!Config.instance().isDevelopmentEnvironment()) {
             throw new AccessDeniedException("You cannot view logs!");
         }
-        return new BytesView(getPath(),StringUtil.readBytes(new FileInputStream(String.format("tmp/java_info0.log.%d",id)),true),MimeType.TEXT_PLAIN);
+        return new BytesView(getPath(), StringUtil.readBytes(new FileInputStream(String.format("tmp/java_info0.log.%d", id)), true), MimeType.TEXT_PLAIN);
     }
 
     /**
      * Returns an ACK Response.
-     * @param request - Incoming  Request
+     *
+     * @param request - Incoming Request
      * @return - ACK Response
      */
-    public View ack(Request request){
+    public View ack(Request request) {
         Acknowledgement ack = new Acknowledgement(Status.ACK);
         String responseString = new Response(ack).toString();
-        Config.instance().getLogger(BgController.class.getName()).log(Level.INFO,responseString);
+        Config.instance().getLogger(BgController.class.getName()).log(Level.INFO, responseString);
 
-        return new BytesView(getPath(),responseString.getBytes(StandardCharsets.UTF_8) , MimeType.APPLICATION_JSON);
+        return new BytesView(getPath(), responseString.getBytes(StandardCharsets.UTF_8), MimeType.APPLICATION_JSON);
     }
-
 
     private static Subscriber getCriteria(Context context) {
         Subscriber criteria = new Subscriber();
         String countryCode = context.getCountry();
         String cityCode = context.getCity();
-        if (countryCode != null){
+        if (countryCode != null) {
             criteria.setCountry(countryCode);
         }
-        if (!ObjectUtil.isVoid(cityCode)){
-            if (!ObjectUtil.isVoid(context.getVersion())){
+        if (!ObjectUtil.isVoid(cityCode)) {
+            if (!ObjectUtil.isVoid(context.getVersion())) {
                 //1.x
                 criteria.setLocation(new Location());
                 criteria.getLocation().setCity(new City());
                 criteria.getLocation().getCity().setCode(cityCode);
-            }else {
+            } else {
                 criteria.setCity(cityCode);
             }
         }
@@ -148,7 +155,8 @@ public class BgController extends Controller {
 
         return criteria;
     }
-    private View act(){
+
+    private View act() {
         Request request = null;
         try {
             request = new Request(StringUtil.read(getPath().getInputStream()));
@@ -161,66 +169,65 @@ public class BgController extends Controller {
             /*
             Validate signature if authorization is enabled
              */
-            if (!GWConfig.isAuthorizationHeaderEnabled() ||
-                    request.verifySignature("Authorization",getPath().getHeaders() , GWConfig.isAuthorizationHeaderMandatory())){
+            if (!GWConfig.isAuthorizationHeaderEnabled()
+                    || request.verifySignature("Authorization", getPath().getHeaders(), GWConfig.isAuthorizationHeaderMandatory())) {
                 Context context = request.getContext();
-                if ("search".equals(request.getContext().getAction())){
+                if ("search".equals(request.getContext().getAction())) {
                     /* Get basic meta from context */
                     Subscriber criteria = getCriteria(request.getContext());
 
                     criteria.setType(Subscriber.SUBSCRIBER_TYPE_BPP);
 
-                    if (!ObjectUtil.isVoid(context.getBppId())){
+                    if (!ObjectUtil.isVoid(context.getBppId())) {
                         criteria.setSubscriberId(context.getBppId());
                     }
 
                     /* lookup for bpps in the domain and city/country */
-                    Map<String,Subscriber> subscriberMap = new HashMap<>(){{
-                        for (Subscriber s : BecknPublicKeyFinder.lookup(criteria)){
-                            put(s.getSubscriberId(),s);
+                    Map<String, Subscriber> subscriberMap = new HashMap<>() {
+                        {
+                            for (Subscriber s : BecknPublicKeyFinder.lookup(criteria)) {
+                                put(s.getSubscriberId(), s);
+                            }
                         }
-                    }};
+                    };
 
-                    Map<String,Subscriber> subscribersWithInternalCatalog = new HashMap<>();
-
+                    Map<String, Subscriber> subscribersWithInternalCatalog = new HashMap<>();
 
                     ModelReflector<Provider> ref = ModelReflector.instance(Provider.class);
-                    List<Provider> tmpProviders = new Select("MAX(ID) AS ID","SUBSCRIBER_ID").from(Provider.class).
-                            where(new Expression(ref.getPool(),"SUBSCRIBER_ID",Operator.IN,subscriberMap.keySet().toArray(new String[]{}))).
+                    List<Provider> tmpProviders = new Select("MAX(ID) AS ID", "SUBSCRIBER_ID").from(Provider.class).
+                            where(new Expression(ref.getPool(), "SUBSCRIBER_ID", Operator.IN, subscriberMap.keySet().toArray(new String[]{}))).
                             groupBy("SUBSCRIBER_ID").execute();
 
                     for (Provider tmpProvider : tmpProviders) {
-                        subscribersWithInternalCatalog.put(tmpProvider.getSubscriberId(),subscriberMap.remove(tmpProvider.getSubscriberId()));
+                        subscribersWithInternalCatalog.put(tmpProvider.getSubscriberId(), subscriberMap.remove(tmpProvider.getSubscriberId()));
                     }
 
-                   tasks.add(new Search(request,subscriberMap,getPath().getHeaders(),false));
-                   tasks.add(new Search(request,subscribersWithInternalCatalog,getPath().getHeaders(),true));
-                }else if ("on_search".equals(request.getContext().getAction())){
+                    tasks.add(new Search(request, subscriberMap, getPath().getHeaders(), false));
+                    tasks.add(new Search(request, subscribersWithInternalCatalog, getPath().getHeaders(), true));
+                } else if ("on_search".equals(request.getContext().getAction())) {
                     Subscriber criteria = getCriteria(request.getContext());
                     IgnoreCaseMap<String> headers = new IgnoreCaseMap<>();
                     headers.putAll(getPath().getHeaders());
-                    String bubbling = headers.getOrDefault("X-Bubbling","N");
-
-
+                    String bubbling = headers.getOrDefault("X-Bubbling", "N");
 
                     if (!ObjectUtil.isVoid(context.getBapId())) {
                         criteria.setType(Subscriber.SUBSCRIBER_TYPE_BAP);
                         criteria.setSubscriberId(context.getBapId());
-                    }else {
-                        if (ObjectUtil.equals(bubbling,"Y")){
+                    } else {
+                        if (ObjectUtil.equals(bubbling, "Y")) {
                             //Coming from another BG.
                             criteria.setSubscriberId(GWConfig.getSubscriberId());
                         }
                         criteria.setType(Subscriber.SUBSCRIBER_TYPE_BG);
                     }
-                        /* For each subscriber submit an async task Will be only one, the BAP who fired the search*/
+                    /* For each subscriber submit an async task Will be only one, the BAP who fired the search*/
                     List<Subscriber> subscriberList = BecknPublicKeyFinder.lookup(criteria);
-                    headers.put("X-Bubbling","Y");
+                    headers.put("X-Bubbling", "Y");
 
-                    for (Subscriber subscriber : subscriberList){
-                        if (!ObjectUtil.equals(subscriber.getSubscriberId(),GWConfig.getSubscriberId())) {
+                    for (Subscriber subscriber : subscriberList) {
+                        if (!ObjectUtil.equals(subscriber.getSubscriberId(), GWConfig.getSubscriberId())) {
                             tasks.add(new OnSearch(request, subscriber, headers));
-                        }else {
+                        } else {
                             Request internal = new Request();
                             internal.update(request);
                             tasks.add(new CatalogDigester(internal.getContext(), internal.getMessage().getCatalog()));
@@ -229,17 +236,17 @@ public class BgController extends Controller {
                 }
                 //* As the tasks are not critical, these are not persisted. Non persistence also gives speed. And Persistence requires tasks to be serializable.
                 Collections.shuffle(tasks);
-                TaskManager.instance().executeAsync(tasks,false); //Submit all async tasks.
-                BGEventEmitter.getInstance().log_request_processed(context,tasks.size());
+                TaskManager.instance().executeAsync(tasks, false); //Submit all async tasks.
+                BGEventEmitter.getInstance().log_request_processed(context, tasks.size());
                 return ack(request);
-            }else {
-                return nack(request,request.getContext().getBapId());
+            } else {
+                return nack(request, request.getContext().getBapId());
             }
-        }catch (Exception ex){
-            if (request == null){
+        } catch (Exception ex) {
+            if (request == null) {
                 throw new RuntimeException();
             }
-            Request response  = new Request();
+            Request response = new Request();
             Error error = new Error();
             response.setContext(request.getContext());
             response.setError(error);
@@ -247,14 +254,14 @@ public class BgController extends Controller {
             StringWriter message = new StringWriter();
             ex.printStackTrace(new PrintWriter(message));
             error.setMessage(message.toString());
-            Config.instance().getLogger(BgController.class.getName()).log(Level.WARNING,message.toString());
-            return new BytesView(getPath(),response.toString().getBytes(StandardCharsets.UTF_8),MimeType.APPLICATION_JSON);
+            Config.instance().getLogger(BgController.class.getName()).log(Level.WARNING, message.toString());
+            return new BytesView(getPath(), response.toString().getBytes(StandardCharsets.UTF_8), MimeType.APPLICATION_JSON);
         }
     }
 
-
     /**
      * /search call is delegated to act
+     *
      * @return the ACK/NACK response
      */
     @RequireLogin(false)
@@ -265,6 +272,7 @@ public class BgController extends Controller {
 
     /**
      * /on_search call is delegated to act
+     *
      * @return the ACK/NACK response
      */
     @RequireLogin(false)
@@ -272,16 +280,16 @@ public class BgController extends Controller {
         return act();
     }
 
-  protected static Map<String, String> getHeaders(Request request) {
-        Map<String,String> headers  = new HashMap<>();
+    protected static Map<String, String> getHeaders(Request request) {
+        Map<String, String> headers = new HashMap<>();
         if (GWConfig.isAuthorizationHeaderEnabled()) {
 
             String subscriberId = GWConfig.getSubscriberId();
             String pub_key_id = GWConfig.getPublicKeyId();
-            String authHeader = request.generateAuthorizationHeader(subscriberId,pub_key_id);
+            String authHeader = request.generateAuthorizationHeader(subscriberId, pub_key_id);
             headers.put("X-Gateway-Authorization", authHeader);
             headers.put("Proxy-Authorization", authHeader);
-            headers.put("Authorization",authHeader);
+            headers.put("Authorization", authHeader);
 
         }
         headers.put("Content-Type", MimeType.APPLICATION_JSON.toString());
@@ -290,21 +298,33 @@ public class BgController extends Controller {
         return headers;
     }
 
+    public static class SortByLastInteraction implements Comparator<Subscriber> {
+        // Used for sorting in ascending order of 
+        // last interaction 
 
+        @Override
+        public int compare(Subscriber a, Subscriber b) {
+            return a.getLastInteraction().compareTo(b.getLastInteraction());
+        }
+    }
 
     public static class Search implements Task {
+
         Request originalRequest;
-        Map<String,Subscriber> subscriberMap;
-        Map<String,String> headers;
+        Map<String, Subscriber> subscriberMap;
+        Map<String, String> headers;
         NetworkAdaptor networkAdaptor;
         boolean internalCatalog = false;
 
-        public Search(Request request, Subscriber bpp, Map<String, String> headers){
-            this(request,new HashMap<>(){{
-                put(bpp.getSubscriberId(),bpp);
-            }},headers,false);
+        public Search(Request request, Subscriber bpp, Map<String, String> headers) {
+            this(request, new HashMap<>() {
+                {
+                    put(bpp.getSubscriberId(), bpp);
+                }
+            }, headers, false);
         }
-        public Search(Request request, Map<String, Subscriber> subscriberMap, Map<String, String> headers,boolean internalCatalog){
+
+        public Search(Request request, Map<String, Subscriber> subscriberMap, Map<String, String> headers, boolean internalCatalog) {
             this.networkAdaptor = NetworkAdaptorFactory.getInstance().getAdaptor(GWConfig.getNetworkId());
             this.originalRequest = request;
             this.subscriberMap = subscriberMap;
@@ -315,11 +335,11 @@ public class BgController extends Controller {
         @Override
         public void execute() {
             ECEventEmitter ecEventEmitter = new ECEventEmitter();
-            if (ecEventEmitter.isEventPublishingRequired(originalRequest)){
-                try{
-                    long maxSleepTime = 2*1000L; //2 seconds
-                    Thread.sleep(Math.max(Config.instance().getLongProperty("ec.sleep.time.millis",maxSleepTime),maxSleepTime));
-                }catch (Exception ex){
+            if (ecEventEmitter.isEventPublishingRequired(originalRequest)) {
+                try {
+                    long maxSleepTime = 2 * 1000L; //2 seconds
+                    Thread.sleep(Math.max(Config.instance().getLongProperty("ec.sleep.time.millis", maxSleepTime), maxSleepTime));
+                } catch (Exception ex) {
                     //
                 }
             }
@@ -327,24 +347,20 @@ public class BgController extends Controller {
                 ecEventEmitter.emit(bpp, originalRequest);
             }
 
-
-
-
-
-            String bgPublicKey = Request.getPublicKey(GWConfig.getSubscriberId(),GWConfig.getPublicKeyId());
-            if (internalCatalog){
+            String bgPublicKey = Request.getPublicKey(GWConfig.getSubscriberId(), GWConfig.getPublicKeyId());
+            if (internalCatalog) {
                 CatalogSearchEngine searchEngine = new CatalogSearchEngine(subscriberMap);
                 Context context = originalRequest.getContext();
                 Subscriber criteria = getCriteria(context);
                 criteria.setType(Subscriber.SUBSCRIBER_TYPE_BAP);
-                List<Subscriber> bapList ;
+                List<Subscriber> bapList;
                 if (!ObjectUtil.isVoid(context.getBapId())) {
                     criteria.setSubscriberId(context.getBapId());
                     bapList = BecknPublicKeyFinder.lookup(criteria);
-                }else {
+                } else {
                     bapList = new ArrayList<>();
                 }
-                if (bapList.isEmpty()){
+                if (bapList.isEmpty()) {
                     return;
                 }
 
@@ -354,12 +370,11 @@ public class BgController extends Controller {
                 internalFormatRequest.update(originalRequest);
 
                 List<Request> internalFormatResponses = new ArrayList<>();
-                searchEngine.search(internalFormatRequest,internalFormatResponses);
+                searchEngine.search(internalFormatRequest, internalFormatResponses);
                 Collections.shuffle(internalFormatResponses); // Fairness!! ha ha
 
-
                 for (Request internalFormatResponse : internalFormatResponses) {
-                    if (internalFormatResponse.isSuppressed()){
+                    if (internalFormatResponse.isSuppressed()) {
                         continue;
                     }
                     Request on_search = networkAdaptor.getObjectCreator(originalRequest.getContext().getDomain()).create(Request.class);
@@ -367,16 +382,16 @@ public class BgController extends Controller {
 
                     for (Subscriber bap : bapList) {
                         OnSearch onSearch = new OnSearch(on_search, bap, null);
-                        TaskManager.instance().executeAsync(onSearch,false);
+                        TaskManager.instance().executeAsync(onSearch, false);
                     }
                 }
 
-            }else {
+            } else {
                 List<Subscriber> bpps = new ArrayList<>(subscriberMap.values());
-                Collections.shuffle(bpps);
+                Collections.sort(bpps, new SortByLastInteraction());
                 for (Subscriber bpp : bpps) {
                     TaskManager.instance().executeAsync((IOTask) () -> {
-                        Call < InputStream > call = new Call<InputStream>().url(bpp.getSubscriberUrl() + "/" + originalRequest.getContext().getAction()).
+                        Call< InputStream> call = new Call<InputStream>().url(bpp.getSubscriberUrl() + "/" + originalRequest.getContext().getAction()).
                                 method(HttpMethod.POST).inputFormat(InputFormat.INPUT_STREAM).timeOut(GWConfig.getTimeOut()).
                                 input(new ByteArrayInputStream(originalRequest.toString().getBytes(StandardCharsets.UTF_8))).headers(getHeaders(originalRequest));
 
@@ -384,6 +399,10 @@ public class BgController extends Controller {
                             call.header("Authorization", headers.get("Authorization"));
                         }
                         try {
+                            if (call.getStatus() == 200) {
+                                setLastInteraction(bpp);
+                            }
+
                             if (call.hasErrors() && call.getStatus() > 500 && GWConfig.disableSlowBpp()) {
                                 disableBpp(bpp);
                             }
@@ -392,87 +411,96 @@ public class BgController extends Controller {
                                 disableBpp(bpp);
                             }
                         }
-                    },false);
+                    }, false);
                 }
             }
         }
 
-        public void disableBpp(Subscriber bpp){
+        public void setLastInteraction(Subscriber bpp) {
             Subscriber registry = NetworkAdaptorFactory.getInstance().getAdaptor(GWConfig.getNetworkId()).getRegistry();
 
             Request payload = new Request(bpp.toString());
-            Map<String,String> headers = getHeaders(payload);
-            new Call<InputStream>().method(HttpMethod.POST).url(registry.getSubscriberUrl() ,"/disable").
+            Map<String, String> headers = getHeaders(payload);
+            new Call<InputStream>().method(HttpMethod.POST).url(registry.getSubscriberUrl(), "/setLastInteraction").
                     input(new ByteArrayInputStream(payload.toString().getBytes(StandardCharsets.UTF_8))).inputFormat(InputFormat.INPUT_STREAM).headers(headers).hasErrors();
         }
 
+        public void disableBpp(Subscriber bpp) {
+            Subscriber registry = NetworkAdaptorFactory.getInstance().getAdaptor(GWConfig.getNetworkId()).getRegistry();
+
+            Request payload = new Request(bpp.toString());
+            Map<String, String> headers = getHeaders(payload);
+            new Call<InputStream>().method(HttpMethod.POST).url(registry.getSubscriberUrl(), "/disable").
+                    input(new ByteArrayInputStream(payload.toString().getBytes(StandardCharsets.UTF_8))).inputFormat(InputFormat.INPUT_STREAM).headers(headers).hasErrors();
+        }
 
     }
 
     public static class OnSearch implements IOTask {
+
         Request originalRequest;
-        Subscriber bap ;
-        Map<String,String> headers;
-        public OnSearch(Request request, Subscriber bap, Map<String, String> headers){
+        Subscriber bap;
+        Map<String, String> headers;
+
+        public OnSearch(Request request, Subscriber bap, Map<String, String> headers) {
             this.originalRequest = request;
             this.bap = bap;
             this.headers = headers;
         }
+
         @Override
         public void execute() {
             ECEventEmitter ecEventEmitter = new ECEventEmitter();
-            if (ecEventEmitter.isEventPublishingRequired(originalRequest)){
-                try{
-                    long maxSleepTime = 2*1000L; //2 seconds
-                    Thread.sleep(Math.max(Config.instance().getLongProperty("bg.ec.sleep.time.millis",maxSleepTime),maxSleepTime));
-                }catch (Exception ex){
+            if (ecEventEmitter.isEventPublishingRequired(originalRequest)) {
+                try {
+                    long maxSleepTime = 2 * 1000L; //2 seconds
+                    Thread.sleep(Math.max(Config.instance().getLongProperty("bg.ec.sleep.time.millis", maxSleepTime), maxSleepTime));
+                } catch (Exception ex) {
                     //
                 }
             }
 
-            Call<InputStream> call = new Call<InputStream>().url(bap.getSubscriberUrl()+ "/"+originalRequest.getContext().getAction()).
+            Call<InputStream> call = new Call<InputStream>().url(bap.getSubscriberUrl() + "/" + originalRequest.getContext().getAction()).
                     method(HttpMethod.POST).inputFormat(InputFormat.INPUT_STREAM).timeOut(GWConfig.getTimeOut()). //5 Seconds
                     input(new ByteArrayInputStream(originalRequest.toString().getBytes(StandardCharsets.UTF_8))).headers(getHeaders(originalRequest));
-            if (this.headers != null && headers.containsKey("Authorization")){
-                call.header("Authorization",headers.get("Authorization"));
+            if (this.headers != null && headers.containsKey("Authorization")) {
+                call.header("Authorization", headers.get("Authorization"));
             }
-            new ECEventEmitter().emit(bap,originalRequest);
+            new ECEventEmitter().emit(bap, originalRequest);
             call.getResponseAsJson();
         }
     }
 
-
     @RequireLogin(value = false)
     @SuppressWarnings("unchecked")
-    public View on_subscribe() throws Exception{
+    public View on_subscribe() throws Exception {
         NetworkAdaptor networkAdaptor = NetworkAdaptorFactory.getInstance().getAdaptor(GWConfig.getNetworkId());
         String payload = StringUtil.read(getPath().getInputStream());
         JSONObject object = (JSONObject) JSONValue.parse(payload);
 
-
-        if (!Request.verifySignature(getPath().getHeader("Signature"), payload, networkAdaptor.getRegistry().getSigningPublicKey())){
+        if (!Request.verifySignature(getPath().getHeader("Signature"), payload, networkAdaptor.getRegistry().getSigningPublicKey())) {
             throw new RuntimeException("Cannot verify Signature");
         }
 
         PrivateKey privateKey = Crypt.getInstance().getPrivateKey(Request.ENCRYPTION_ALGO,
-                CryptoKey.find(GWConfig.getPublicKeyId(),CryptoKey.PURPOSE_ENCRYPTION).getPrivateKey());
+                CryptoKey.find(GWConfig.getPublicKeyId(), CryptoKey.PURPOSE_ENCRYPTION).getPrivateKey());
 
         PublicKey registryPublicKey = Request.getEncryptionPublicKey(networkAdaptor.getRegistry().getEncrPublicKey());
 
         KeyAgreement agreement = KeyAgreement.getInstance(Request.ENCRYPTION_ALGO);
         agreement.init(privateKey);
-        agreement.doPhase(registryPublicKey,true);
+        agreement.doPhase(registryPublicKey, true);
 
         SecretKey key = agreement.generateSecret("TlsPremasterSecret");
 
         JSONObject output = new JSONObject();
-        output.put("answer", Crypt.getInstance().decrypt((String)object.get("challenge"),"AES",key));
+        output.put("answer", Crypt.getInstance().decrypt((String) object.get("challenge"), "AES", key));
 
-        return new BytesView(getPath(),output.toString().getBytes(),MimeType.APPLICATION_JSON);
+        return new BytesView(getPath(), output.toString().getBytes(), MimeType.APPLICATION_JSON);
     }
 
     public View subscribe() {
         AppInstaller.registerBecknKeys();
-        return IntegrationAdaptor.instance(SWFHttpResponse.class, FormatHelper.getFormatClass(MimeType.APPLICATION_JSON)).createStatusResponse(getPath(),null);
+        return IntegrationAdaptor.instance(SWFHttpResponse.class, FormatHelper.getFormatClass(MimeType.APPLICATION_JSON)).createStatusResponse(getPath(), null);
     }
 }


### PR DESCRIPTION
### Brief
Tried to resolve a currently ongoing issue with the beckn gateway wherein lots of localtunnel bpps being registered on the gateway are slowing `search` calls, as the gateway was randomly shuffling the list of bpps and sending a request to them with a 5-second timeout.

### Approach
For resolving this issue, I've added a new column called `last_interaction` in the `Subscriber` class (in `[beckn-sdk-java](https://github.com/beckn-on-succinct/beckn-sdk-java)` codebase) as well as `NetworkRole` model (in `[beckn-registry](https://github.com/beckn-on-succinct/beckn-registry)` codebase).

The `lastInteraction` field aims to store the timestamp of the last successful interfaction (HTTP Status Code 200) of the bpp with the gateway.

This codebase has been modified to now sort the bpps list by their lastInteraction times, instead of randomly shuffling them before sending out the requests to the BPP.

This will ensure active and healthy BPP servers are always prioritised by the gateway over inactive ones, so that, consequently the gateway itself doesn't experience an lags. This will also ensure fairness to parties investing in hosting infrastructure to keep their BPP up & running with the best possible health.

### Considerations

- While the commits made by me aim to modify the various involved codebases, this is just the logic side of things, database schema changes are also required to accomodate this change.
- The changes committed by me might not also be complete and the change might need to be propagated accross other parts of the system as well, in order to avoid breaking anything. I'd be happy to help out with the same with necessary guidance.
- This change is **NOT** backward-compatible.
- As a future consideration, before deploying this change, it should also be evaluated in terms of how much it might hamper the overall performance of the current system.
 